### PR TITLE
Issue #37: Change login button flex container to height auto and add margin to buttons

### DIFF
--- a/Components/Auth/Auth.js
+++ b/Components/Auth/Auth.js
@@ -33,7 +33,7 @@ const styles = StyleSheet.create({
         display: 'flex',
         justifyContent: 'space-between',
         alignItems: 'center',
-        height: '30%',
+        height: 'auto',
     },
     Container: {
         display: 'flex',

--- a/Components/Auth/Auth.js
+++ b/Components/Auth/Auth.js
@@ -31,9 +31,9 @@ const Auth = () => {
 const styles = StyleSheet.create({
     ButtonContainer: {
         display: 'flex',
-        justifyContent: 'space-around',
+        justifyContent: 'space-between',
         alignItems: 'center',
-        height: '20%',
+        height: '30%',
     },
     Container: {
         display: 'flex',

--- a/Components/Auth/SocialAuthButton.js
+++ b/Components/Auth/SocialAuthButton.js
@@ -88,6 +88,7 @@ const styles = StyleSheet.create({
         alignItems: 'center',
         minWidth: 280,
         width: '70%',
+        margin: 5,
         borderRadius: StyleConstants.BASE_BORDER_RADIUS,
         backgroundColor: platform.color.primary,
     }),


### PR DESCRIPTION
Fix for issue #37 that changes the flexbox container  to height auto and add margin to buttons to fix overlapping issue on android:

NOTE: The extra spotify button was just used for testing and is not present in this PR 

![image](https://user-images.githubusercontent.com/19170236/74798625-3ec9a680-529c-11ea-9add-bf874c94497a.png)
